### PR TITLE
fix: Rename action to 'NextJS Cache'

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: "Next.js Cache"
+name: "NextJS Cache"
 description: "Cache Next.js build outputs in GitHub Actions."
 author: "jongwooo <jongwooo.han@gmail.com>"
 


### PR DESCRIPTION
## Description

> Name must be unique. Cannot match an existing action, user or organization name.

Rename action from 'Next.js Cache' to 'NextJS Cache'.