### PR TITLE
fix(action): fix pnpm cache key calculation

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,9 +10,9 @@ runs:
         path: |
           ${{ github.workspace }}/.next/cache
         key: |
-          ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json', '**/npm-shrinkwrap.json', '**/yarn.lock', '**/pnpm-lock.yaml)') }}-${{ hashFiles('**.[jt]s', '**.[jt]sx') }}
+          ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json', '**/npm-shrinkwrap.json', '**/yarn.lock', '**/pnpm-lock.yaml') }}-${{ hashFiles('**.[jt]s', '**.[jt]sx') }}
         restore-keys: |
-          ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json', '**/npm-shrinkwrap.json', '**/yarn.lock', '**/pnpm-lock.yaml)') }}
+          ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json', '**/npm-shrinkwrap.json', '**/yarn.lock', '**/pnpm-lock.yaml') }}
 branding:
   icon: "archive"
   color: "black"


### PR DESCRIPTION
There's an extra character in the pnpm-lock string that's preventing pnpm-lock files from being included in the key calculation.