### PR TITLE
fix(action): fix file key hash calculation

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ runs:
         path: |
           ${{ github.workspace }}/.next/cache
         key: |
-          ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json', '**/npm-shrinkwrap.json', '**/yarn.lock', '**/pnpm-lock.yaml)') }}-${{ hashFiles('**.[jt]s', '**.[jt]sx') }}
+          ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json', '**/npm-shrinkwrap.json', '**/yarn.lock', '**/pnpm-lock.yaml)') }}-${{ hashFiles('**/*.js', '**/*.jsx', '**/*.ts', '**/*.tsx') }}
         restore-keys: |
           ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json', '**/npm-shrinkwrap.json', '**/yarn.lock', '**/pnpm-lock.yaml)') }}
 branding:


### PR DESCRIPTION
Currently, the portion of the cache key that caches files isn't matching correctly. Here you can see the last part of the key is empty (current setup):

![CleanShot 2023-06-29 at 15 46 15](https://github.com/jongwooo/next-cache/assets/37197876/33950fc5-ee96-4a74-89a5-31d0d094249e)

Changing the blob patterns to more explicit seems to match the files correctly (proposed fix):

![CleanShot 2023-06-29 at 15 47 47](https://github.com/jongwooo/next-cache/assets/37197876/203b9260-f7c1-4531-a1de-d09d4b94a9f0)

